### PR TITLE
Implement server-side bidding timer and polling demo

### DIFF
--- a/api/bid.php
+++ b/api/bid.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+require __DIR__ . '/db.php';
+
+header('Cache-Control: no-store, no-cache, must-revalidate');
+
+$code = $_GET['code'] ?? null;
+if ($code === null || $code === '') {
+    respondJson(400, ['error' => 'Missing room code.']);
+}
+
+$raw = file_get_contents('php://input');
+if ($raw === false) {
+    respondJson(400, ['error' => 'Missing request body.']);
+}
+
+$payload = json_decode($raw, true);
+if (!is_array($payload)) {
+    respondJson(400, ['error' => 'Invalid JSON payload.']);
+}
+
+if (!array_key_exists('playerId', $payload) || !array_key_exists('value', $payload)) {
+    respondJson(400, ['error' => 'playerId and value are required.']);
+}
+
+$playerId = (int) $payload['playerId'];
+$bidValue = (int) $payload['value'];
+
+if ($playerId <= 0 || $bidValue <= 0) {
+    respondJson(400, ['error' => 'playerId and value must be positive integers.']);
+}
+
+$pdo = db();
+
+try {
+    $pdo->beginTransaction();
+
+    $round = lockRoundForUpdateByRoomCode($code);
+    if ($round === null) {
+        $pdo->rollBack();
+        respondJson(404, ['error' => 'Room not found or no active round.']);
+    }
+
+    $updated = false;
+
+    if ($round['status'] === 'bidding' && empty($round['bidding_ends_at'])) {
+        $endsAt = startCountdown((int) $round['id']);
+        $round['status'] = 'countdown';
+        $round['bidding_ends_at'] = $endsAt;
+        $updated = true;
+    }
+
+    if ($round['status'] !== 'countdown') {
+        $pdo->rollBack();
+        respondJson(409, ['error' => 'Bidding is closed for the current round.']);
+    }
+
+    $currentLow = array_key_exists('current_low_bid', $round) ? $round['current_low_bid'] : null;
+    $shouldUpdateLow = $currentLow === null || $bidValue < (int) $currentLow;
+
+    if ($shouldUpdateLow) {
+        setNewLowBid((int) $round['id'], $playerId, $bidValue);
+        $updated = true;
+    }
+
+    insertBid((int) $round['id'], $playerId, $bidValue);
+
+    if ($updated) {
+        bumpVersion((int) $round['id']);
+    }
+
+    $pdo->commit();
+} catch (Throwable $e) {
+    if ($pdo->inTransaction()) {
+        $pdo->rollBack();
+    }
+    respondJson(500, ['error' => 'Unable to record bid.']);
+}
+
+respondJson(200, ['ok' => true]);
+
+function respondJson(int $status, array $payload): void
+{
+    http_response_code($status);
+    header('Content-Type: application/json');
+    echo json_encode($payload);
+    exit;
+}

--- a/api/state.php
+++ b/api/state.php
@@ -1,0 +1,129 @@
+<?php
+
+declare(strict_types=1);
+
+require __DIR__ . '/db.php';
+
+header('Cache-Control: no-store, no-cache, must-revalidate');
+
+$code = $_GET['code'] ?? null;
+if ($code === null || $code === '') {
+    respondJson(400, ['error' => 'Missing room code.']);
+}
+
+$since = isset($_GET['since']) ? (int) $_GET['since'] : -1;
+$timeoutAt = microtime(true) + 25.0;
+
+while (microtime(true) < $timeoutAt) {
+    try {
+        $round = fetchCurrentRoundByRoomCode($code);
+    } catch (Throwable $e) {
+        respondJson(500, ['error' => 'Failed to load round.']);
+    }
+
+    if ($round === null) {
+        respondJson(404, ['error' => 'Room not found or no active round.']);
+    }
+
+    $now = new DateTimeImmutable('now', new DateTimeZone('UTC'));
+
+    if (!empty($round['bidding_ends_at']) && $round['status'] === 'countdown') {
+        try {
+            $endsAt = new DateTimeImmutable($round['bidding_ends_at'], new DateTimeZone('UTC'));
+        } catch (Exception $e) {
+            $endsAt = null;
+        }
+
+        if ($endsAt !== null && $now >= $endsAt) {
+            $pdo = db();
+            try {
+                $pdo->beginTransaction();
+                $locked = lockRoundForUpdateById((int) $round['id']);
+                if ($locked !== null && $locked['status'] === 'countdown' && !empty($locked['bidding_ends_at'])) {
+                    try {
+                        $lockedEnds = new DateTimeImmutable($locked['bidding_ends_at'], new DateTimeZone('UTC'));
+                    } catch (Exception $e) {
+                        $lockedEnds = null;
+                    }
+
+                    if ($lockedEnds !== null && $now >= $lockedEnds) {
+                        setRoundStatus((int) $locked['id'], 'verifying');
+                        bumpVersion((int) $locked['id']);
+                    }
+                }
+                $pdo->commit();
+            } catch (Throwable $e) {
+                if ($pdo->inTransaction()) {
+                    $pdo->rollBack();
+                }
+                respondJson(500, ['error' => 'Failed to advance round state.']);
+            }
+
+            // Refresh the state immediately after an automatic transition.
+            usleep(20000);
+            continue;
+        }
+    }
+
+    $currentVersion = isset($round['state_version']) ? (int) $round['state_version'] : 0;
+
+    if ($currentVersion !== $since) {
+        $remaining = null;
+        if (!empty($round['bidding_ends_at'])) {
+            try {
+                $endsAt = new DateTimeImmutable($round['bidding_ends_at'], new DateTimeZone('UTC'));
+                $diff = $endsAt->getTimestamp() - $now->getTimestamp();
+                $remaining = max(0, $diff);
+            } catch (Exception $e) {
+                $remaining = null;
+            }
+        }
+
+        $currentLow = array_key_exists('current_low_bid', $round) && $round['current_low_bid'] !== null
+            ? (int) $round['current_low_bid']
+            : null;
+        $currentLowBy = array_key_exists('current_low_bidder_player_id', $round) && $round['current_low_bidder_player_id'] !== null
+            ? (int) $round['current_low_bidder_player_id']
+            : null;
+
+        $bids = [];
+        try {
+            $bids = fetchRecentBids((int) $round['id']);
+        } catch (Throwable $e) {
+            $bids = [];
+        }
+
+        $leaderboard = [];
+        try {
+            $leaderboard = fetchLeaderboard((int) $round['room_id']);
+        } catch (Throwable $e) {
+            $leaderboard = [];
+        }
+
+        $payload = [
+            'stateVersion' => $currentVersion,
+            'status'       => $round['status'],
+            'remaining'    => $remaining,
+            'currentLow'   => $currentLow,
+            'currentLowBy' => $currentLowBy,
+            'bids'         => $bids,
+            'leaderboard'  => $leaderboard,
+            'serverNow'    => $now->format(DateTimeInterface::ATOM),
+        ];
+
+        respondJson(200, $payload);
+    }
+
+    usleep(200000);
+}
+
+http_response_code(204);
+exit;
+
+function respondJson(int $status, array $payload): void
+{
+    http_response_code($status);
+    header('Content-Type: application/json');
+    echo json_encode($payload);
+    exit;
+}

--- a/db/migrations/202502140000_add_state_version_bidding_ends_at.sql
+++ b/db/migrations/202502140000_add_state_version_bidding_ends_at.sql
@@ -1,0 +1,27 @@
+ALTER TABLE rounds
+  ADD COLUMN state_version INT NOT NULL DEFAULT 0,
+  ADD COLUMN bidding_ends_at DATETIME NULL;
+
+SET @room_idx := (
+  SELECT COUNT(1)
+  FROM information_schema.statistics
+  WHERE table_schema = DATABASE()
+    AND table_name = 'rounds'
+    AND index_name = 'idx_rounds_room'
+);
+SET @sql := IF(@room_idx = 0, 'CREATE INDEX idx_rounds_room ON rounds(room_id);', 'DO 0;');
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+SET @status_idx := (
+  SELECT COUNT(1)
+  FROM information_schema.statistics
+  WHERE table_schema = DATABASE()
+    AND table_name = 'rounds'
+    AND index_name = 'idx_rounds_status'
+);
+SET @sql := IF(@status_idx = 0, 'CREATE INDEX idx_rounds_status ON rounds(status);', 'DO 0;');
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;

--- a/public/demo.html
+++ b/public/demo.html
@@ -1,0 +1,245 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Ricochet Robot Bidding Demo</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <style>
+    body { font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; margin: 2rem; background: #f7f7f7; }
+    h1 { margin-bottom: 0.5rem; }
+    fieldset { border: 1px solid #ccc; padding: 1rem; margin-bottom: 1.5rem; background: #fff; }
+    label { display: block; margin-bottom: 0.5rem; }
+    input, select, button { padding: 0.5rem; font-size: 1rem; }
+    .status { font-size: 1.25rem; margin: 0.5rem 0; }
+    .timer { font-size: 2rem; font-weight: bold; }
+    ul { padding-left: 1.5rem; }
+    .columns { display: flex; flex-wrap: wrap; gap: 1.5rem; }
+    .columns > div { flex: 1 1 250px; }
+    table { width: 100%; border-collapse: collapse; }
+    th, td { border: 1px solid #ddd; padding: 0.5rem; text-align: left; }
+    .error { color: #b00020; }
+  </style>
+  <script src="js/polling.js" defer></script>
+</head>
+<body>
+  <h1>Ricochet Robot Bidding Demo</h1>
+  <p>Use this page to experiment with the server-authoritative bidding timer. Join the same room code in two tabs to observe live updates.</p>
+
+  <fieldset>
+    <legend>Join Room</legend>
+    <form id="join-form">
+      <label>
+        Room code
+        <input id="room-code" type="text" required minlength="1" maxlength="12" autocomplete="off">
+      </label>
+      <label>
+        Player ID
+        <input id="player-id" type="number" required min="1" step="1">
+      </label>
+      <label>
+        Polling mode
+        <select id="polling-mode">
+          <option value="adaptive">Adaptive short polling</option>
+          <option value="long">Long polling</option>
+        </select>
+      </label>
+      <button type="submit">Connect</button>
+      <span id="join-error" class="error" aria-live="polite"></span>
+    </form>
+  </fieldset>
+
+  <fieldset>
+    <legend>Current Round</legend>
+    <div class="status">
+      Status: <span id="status">—</span> (state version <span id="state-version">0</span>)
+    </div>
+    <div class="timer">
+      Time Remaining: <span id="remaining">—</span>
+    </div>
+    <div>
+      Lowest Bid: <span id="low-bid">—</span>
+      <span id="low-bidder"></span>
+    </div>
+  </fieldset>
+
+  <div class="columns">
+    <div>
+      <h2>Recent Bids</h2>
+      <ul id="bids"></ul>
+    </div>
+    <div>
+      <h2>Leaderboard</h2>
+      <table>
+        <thead>
+          <tr>
+            <th>Player</th>
+            <th>Points</th>
+          </tr>
+        </thead>
+        <tbody id="leaderboard"></tbody>
+      </table>
+    </div>
+  </div>
+
+  <fieldset>
+    <legend>Submit Bid</legend>
+    <form id="bid-form">
+      <label>
+        Bid value
+        <input id="bid-value" type="number" min="1" step="1" required>
+      </label>
+      <button type="submit">Submit Bid</button>
+      <span id="bid-error" class="error" aria-live="polite"></span>
+    </form>
+  </fieldset>
+
+  <script>
+    (function () {
+      const joinForm = document.getElementById('join-form');
+      const bidForm = document.getElementById('bid-form');
+      const roomCodeInput = document.getElementById('room-code');
+      const playerIdInput = document.getElementById('player-id');
+      const pollingModeInput = document.getElementById('polling-mode');
+      const joinError = document.getElementById('join-error');
+      const bidError = document.getElementById('bid-error');
+
+      const statusEl = document.getElementById('status');
+      const versionEl = document.getElementById('state-version');
+      const remainingEl = document.getElementById('remaining');
+      const lowBidEl = document.getElementById('low-bid');
+      const lowBidderEl = document.getElementById('low-bidder');
+      const bidsEl = document.getElementById('bids');
+      const leaderboardEl = document.getElementById('leaderboard');
+
+      let poller = null;
+      let currentRoomCode = null;
+      let currentPlayerId = null;
+      let lastServerRemaining = null;
+      let lastServerTimestamp = null;
+
+      function formatSeconds(seconds) {
+        if (seconds == null) {
+          return '—';
+        }
+        const s = Math.max(0, Math.floor(seconds));
+        const mins = Math.floor(s / 60);
+        const secs = s % 60;
+        return mins > 0 ? `${mins}:${secs.toString().padStart(2, '0')}` : `${secs}`;
+      }
+
+      function renderAll(state) {
+        joinError.textContent = '';
+        statusEl.textContent = state.status;
+        versionEl.textContent = state.stateVersion;
+        remainingEl.textContent = formatSeconds(state.remaining);
+        lowBidEl.textContent = state.currentLow != null ? state.currentLow : '—';
+        lowBidderEl.textContent = state.currentLowBy != null ? `(by ${state.currentLowBy})` : '';
+
+        bidsEl.innerHTML = '';
+        (state.bids || []).forEach(function (bid) {
+          const li = document.createElement('li');
+          const when = bid.createdAt ? new Date(bid.createdAt).toLocaleTimeString() : '—';
+          li.textContent = `Player ${bid.playerId} bid ${bid.value} @ ${when}`;
+          bidsEl.appendChild(li);
+        });
+
+        leaderboardEl.innerHTML = '';
+        (state.leaderboard || []).forEach(function (row) {
+          const tr = document.createElement('tr');
+          const nameCell = document.createElement('td');
+          nameCell.textContent = row.name ? `${row.name} (${row.playerId})` : row.playerId;
+          const pointsCell = document.createElement('td');
+          pointsCell.textContent = row.points != null ? row.points : '0';
+          tr.appendChild(nameCell);
+          tr.appendChild(pointsCell);
+          leaderboardEl.appendChild(tr);
+        });
+
+        lastServerRemaining = state.remaining;
+        lastServerTimestamp = Date.parse(state.serverNow);
+      }
+
+      function estimateRemaining(skewMs) {
+        if (lastServerRemaining == null || lastServerTimestamp == null) {
+          return null;
+        }
+        const serverNow = Date.now() + skewMs;
+        const elapsed = Math.floor((serverNow - lastServerTimestamp) / 1000);
+        return Math.max(0, lastServerRemaining - elapsed);
+      }
+
+      joinForm.addEventListener('submit', function (event) {
+        event.preventDefault();
+        if (!window.PollingHelpers) {
+          joinError.textContent = 'Helpers not loaded yet. Please retry.';
+          return;
+        }
+
+        const code = roomCodeInput.value.trim();
+        const player = Number(playerIdInput.value);
+        const mode = pollingModeInput.value;
+
+        if (!code || !player) {
+          joinError.textContent = 'Enter a room code and player id.';
+          return;
+        }
+
+        currentRoomCode = code;
+        currentPlayerId = player;
+        bidError.textContent = '';
+
+        if (poller && typeof poller.stop === 'function') {
+          poller.stop();
+        }
+
+        lastServerRemaining = null;
+        lastServerTimestamp = null;
+
+        try {
+          if (mode === 'long') {
+            poller = window.PollingHelpers.createLongPoller({
+              code: code,
+              renderAll: renderAll
+            });
+            poller.start();
+          } else {
+            poller = window.PollingHelpers.createAdaptivePoller({
+              code: code,
+              renderAll: renderAll,
+              getRemainingFromUI: estimateRemaining
+            });
+            poller.start().catch(function (err) {
+              console.error(err);
+              joinError.textContent = 'Unable to connect to the room.';
+            });
+          }
+        } catch (err) {
+          console.error(err);
+          joinError.textContent = 'Unable to connect to the room.';
+        }
+      });
+
+      bidForm.addEventListener('submit', function (event) {
+        event.preventDefault();
+        bidError.textContent = '';
+
+        if (!currentRoomCode || !currentPlayerId) {
+          bidError.textContent = 'Join a room first.';
+          return;
+        }
+
+        const value = Number(document.getElementById('bid-value').value);
+        if (!Number.isFinite(value) || value <= 0) {
+          bidError.textContent = 'Enter a positive bid value.';
+          return;
+        }
+
+        window.PollingHelpers.submitBid(currentRoomCode, currentPlayerId, value).catch(function (err) {
+          console.error(err);
+          bidError.textContent = 'Bid failed.';
+        });
+      });
+    }());
+  </script>
+</body>
+</html>

--- a/public/js/polling.js
+++ b/public/js/polling.js
@@ -1,0 +1,150 @@
+(function (global) {
+  'use strict';
+
+  function adaptiveDelay(remaining) {
+    if (remaining == null) return 1000;
+    if (remaining > 5) return 1000;
+    if (remaining > 2) return 500;
+    return 250;
+  }
+
+  function createAdaptivePoller(options) {
+    const state = {
+      code: options.code,
+      renderAll: options.renderAll,
+      getRemainingFromUI: options.getRemainingFromUI || function () { return null; },
+      since: -1,
+      serverSkewMs: 0,
+      running: false
+    };
+
+    async function initialSync() {
+      const res = await fetch(`/api/rooms/${encodeURIComponent(state.code)}/state?since=-1`);
+      if (!res.ok) {
+        throw new Error('Failed to load initial state');
+      }
+      const data = await res.json();
+      state.since = data.stateVersion;
+      state.serverSkewMs = Date.parse(data.serverNow) - Date.now();
+      state.renderAll(data);
+    }
+
+    async function pollOnce() {
+      const res = await fetch(`/api/rooms/${encodeURIComponent(state.code)}/state?since=${state.since}`);
+      if (res.status === 204) {
+        return null;
+      }
+      if (!res.ok) {
+        throw new Error('Failed to poll state');
+      }
+      const data = await res.json();
+      state.since = data.stateVersion;
+      state.renderAll(data);
+      return data;
+    }
+
+    async function loop() {
+      if (!state.running) {
+        return;
+      }
+      try {
+        const data = await pollOnce();
+        const remaining = data ? data.remaining : (typeof state.getRemainingFromUI === 'function'
+          ? state.getRemainingFromUI(state.serverSkewMs)
+          : null);
+        setTimeout(loop, adaptiveDelay(remaining));
+      } catch (err) {
+        console.error(err);
+        setTimeout(loop, 1000);
+      }
+    }
+
+    async function start() {
+      if (state.running) {
+        return;
+      }
+      state.running = true;
+      try {
+        await initialSync();
+      } catch (err) {
+        state.running = false;
+        throw err;
+      }
+      loop();
+    }
+
+    function stop() {
+      state.running = false;
+    }
+
+    return {
+      start,
+      stop,
+      getSince: function () { return state.since; }
+    };
+  }
+
+  function createLongPoller(options) {
+    const state = {
+      code: options.code,
+      renderAll: options.renderAll,
+      since: -1,
+      stopped: false
+    };
+
+    async function pollLoop() {
+      if (state.stopped) {
+        return;
+      }
+      try {
+        const controller = new AbortController();
+        const timeout = setTimeout(function () { controller.abort(); }, 30000);
+        const res = await fetch(`/api/rooms/${encodeURIComponent(state.code)}/state?since=${state.since}`, {
+          signal: controller.signal
+        });
+        clearTimeout(timeout);
+        if (res.status !== 204) {
+          if (!res.ok) {
+            throw new Error('Failed to poll state');
+          }
+          const data = await res.json();
+          state.since = data.stateVersion;
+          state.renderAll(data);
+        }
+        if (!state.stopped) {
+          pollLoop();
+        }
+      } catch (err) {
+        console.error(err);
+        if (!state.stopped) {
+          setTimeout(pollLoop, 1000);
+        }
+      }
+    }
+
+    function start() {
+      state.stopped = false;
+      pollLoop();
+    }
+
+    function stop() {
+      state.stopped = true;
+    }
+
+    return { start, stop };
+  }
+
+  async function submitBid(code, playerId, value) {
+    await fetch(`/api/rooms/${encodeURIComponent(code)}/bid`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ playerId: Number(playerId), value: Number(value) })
+    });
+  }
+
+  global.PollingHelpers = {
+    createAdaptivePoller: createAdaptivePoller,
+    createLongPoller: createLongPoller,
+    submitBid: submitBid
+  };
+}(window));


### PR DESCRIPTION
## Summary
- add migration for round state versioning and timer deadline
- implement PHP endpoints for long-poll state sync and bid submission with countdown logic
- provide browser polling helpers and demo page to exercise adaptive polling and bidding UI

## Testing
- php -l api/db.php
- php -l api/state.php
- php -l api/bid.php

------
https://chatgpt.com/codex/tasks/task_e_68d09ad0cb4c832a89e1001e5164c05e