### PR TITLE
Externalize config and add database bootstrap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+# never commit real secrets
+config.php
+rr-config.php
+.env

--- a/.htaccess
+++ b/.htaccess
@@ -1,0 +1,8 @@
+# Enable rewriting
+RewriteEngine On
+
+# /api/rooms/{code}/state  -> /api/state.php?code={code}
+RewriteRule ^api/rooms/([^/]+)/state$ api/state.php?code=$1 [QSA,L]
+
+# /api/rooms/{code}/bid    -> /api/bid.php?code={code}
+RewriteRule ^api/rooms/([^/]+)/bid$   api/bid.php?code=$1   [QSA,L]

--- a/README.md
+++ b/README.md
@@ -1,66 +1,46 @@
-# Ricochet Robots Project for MakeFaire 2017 #
+# Ricochet Robots — Web Multiplayer (work-in-progress)
 
-## Introduction ##
-The project aims to simulate the Ricochet Robots game in to a webpage.
-The game can be played by multiple users at the time. The first user that insert the group name starts the countdown timer, the other users that will connect after, will have the timer set to the same value of the first user.
+This is an experimental, web-based multiplayer adaptation of the board game **Ricochet Robots**  
+(see the original on BoardGameGeek: https://boardgamegeek.com/boardgame/51/ricochet-robots).
 
-The destination cell of the game and the color change eachtime a group reach it and win the round, otherwise the game maintain the same.
+The goal is to let a group on a video call open a shared room URL, bid on solutions, and
+play synchronized rounds with a server-authoritative timer (first bid starts 60s; lower bids
+do not reset the timer), then verify solutions in order of lowest bid.
 
-For the Makefaire i have also add all the necessary functionality to move the real robot with the rest api exposed by the arduino yun.
-## Screenshot ##
+## Credits
 
-### WEBPAGE ###
-On game open:
+This project is forked from: https://github.com/fabiottini/ricochet-robot  
+Huge thanks to the original author for the code and the generous MIT license.
 
-![index](README_DATA/img/screenshot_start.png "Index webpage")
+## Status
 
-On running round:
+Work in progress. Current MVP includes:
+- Server-authoritative countdown with polling/long-polling endpoints
+- Lowest-bid tracking
+- Demo UI for basic interaction
 
-![running game](README_DATA/img/screenshot_running_game.png "Running Game")
+## Install (quick start)
 
-On selected robot:
+1. Create a MySQL database and user on your host.
+2. Copy `config.sample.php` to a **private** location (outside the web root), fill credentials, and set an env var pointing to it:
+   - e.g. in Apache: `SetEnv RR_CONFIG_PATH /home/youruser/secure/rr-config.php`
+3. Run the DB bootstrap:
+   - CLI: `php db/migrate.php`
+   - or import `db/schema.sql` manually
+4. Deploy the code into your web root.
+5. Hit the API to verify:
+   - `GET /api/rooms/TEST/state?since=-1` → JSON
+   - `POST /api/rooms/TEST/bid` with `{"playerId":123,"value":12}` → starts 60s countdown
 
-![selected robot](README_DATA/img/screenshot_selected_robot.png "Selected robot")
+## Pretty API routes
 
-## CONSOLE COMMAND ##
+The `.htaccess` rewrites map pretty URLs to PHP files:
 
-I have add for testing or other purpose some extra command to run in the webbrowser console.
+- `/api/rooms/{code}/state` → `api/state.php?code={code}`
+- `/api/rooms/{code}/bid`   → `api/bid.php?code={code}`
 
-### Random simulation ###
+If rewrites are disabled, you can call the PHP files directly.
 
-To let me test all the possible special cases i have created a game simulator.
-The simulator choose randomly the robot and the movement. 
-If the simulator found an unsafe situation stop the simulation and return the robot and the position that is wrong.
+## License
 
-```
-gen.runSimulation(<NUM_MOVES>)
-//<NUM_MOVES> = represent the number of random moves to do
-
-//es.
-gen.runSimulation(10)
-//run 10 random move
-```
-
-### Read optimal solution ###
-
-Simulate the excution of the optimal solution, pre-evaluated.
-```
-fm.readJSONFromGiuseppeP()
-```
-This command read the file jsonConfiguration/optimal.json and simulate the movements the robots as described in the file.
-
-### Read optimal solution and move the LEGO robot ###
-
-For the makefaire 2017 I build this web game and others guy build the LEGO robots connected with the arduino YUN.
-
-```
-fm.readJSONFromGiuseppeP_SIMULAZIONE_ROBOT()
-```
-
-### CLEAN ALL ###
-
-This command clean all generated files in the game to reset it to the initial state
-
-```
-gen.cleanAll()
-```
+MIT (see LICENSE)

--- a/config.sample.php
+++ b/config.sample.php
@@ -1,0 +1,11 @@
+<?php
+// Copy this file to a safe, private location (ideally outside your web root),
+// fill in real credentials, and point RR_CONFIG_PATH env var at that file.
+return [
+  'db_host'    => 'localhost',
+  'db_name'    => 'ricochet_robot',
+  'db_user'    => 'ricochet_user',
+  'db_pass'    => 'change_me',
+  'db_port'    => 3306,
+  'db_charset' => 'utf8mb4',
+];

--- a/db/migrate.php
+++ b/db/migrate.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+require __DIR__ . '/../api/db.php';
+
+try {
+    $pdo = db();
+} catch (Throwable $e) {
+    fwrite(STDERR, 'Unable to connect to the database: ' . $e->getMessage() . PHP_EOL);
+    exit(1);
+}
+
+$statements = [
+    <<<'SQL'
+CREATE TABLE IF NOT EXISTS rooms (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  code VARCHAR(32) NOT NULL UNIQUE,
+  host_player_id INT NULL,
+  settings_json JSON NULL,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+SQL,
+    <<<'SQL'
+CREATE TABLE IF NOT EXISTS rounds (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  room_id INT NOT NULL,
+  status ENUM('bidding','countdown','verifying','complete') NOT NULL,
+  countdown_started_at DATETIME NULL,
+  bidding_ends_at DATETIME NULL,
+  countdown_secs INT DEFAULT 60,
+  current_low_bid INT NULL,
+  current_low_bidder_player_id INT NULL,
+  winner_player_id INT NULL,
+  state_version INT NOT NULL DEFAULT 0,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  ended_at DATETIME NULL,
+  FOREIGN KEY (room_id) REFERENCES rooms(id) ON DELETE CASCADE,
+  INDEX idx_rounds_room (room_id),
+  INDEX idx_rounds_status (status)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+SQL,
+    <<<'SQL'
+CREATE TABLE IF NOT EXISTS bids (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  round_id INT NOT NULL,
+  player_id INT NOT NULL,
+  value INT NOT NULL,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  FOREIGN KEY (round_id) REFERENCES rounds(id) ON DELETE CASCADE,
+  INDEX idx_bids_round (round_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+SQL,
+    <<<'SQL'
+CREATE TABLE IF NOT EXISTS room_players (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  room_id INT NOT NULL,
+  player_id INT NOT NULL,
+  name VARCHAR(255) NULL,
+  points INT NOT NULL DEFAULT 0,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  UNIQUE KEY uniq_room_player (room_id, player_id),
+  FOREIGN KEY (room_id) REFERENCES rooms(id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+SQL,
+];
+
+foreach ($statements as $sql) {
+    $pdo->exec($sql);
+}
+
+fwrite(STDOUT, "Database schema ensured.\n");

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -1,0 +1,47 @@
+CREATE TABLE IF NOT EXISTS rooms (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  code VARCHAR(32) NOT NULL UNIQUE,
+  host_player_id INT NULL,
+  settings_json JSON NULL,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE IF NOT EXISTS rounds (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  room_id INT NOT NULL,
+  status ENUM('bidding','countdown','verifying','complete') NOT NULL,
+  countdown_started_at DATETIME NULL,
+  bidding_ends_at DATETIME NULL,
+  countdown_secs INT DEFAULT 60,
+  current_low_bid INT NULL,
+  current_low_bidder_player_id INT NULL,
+  winner_player_id INT NULL,
+  state_version INT NOT NULL DEFAULT 0,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  ended_at DATETIME NULL,
+  FOREIGN KEY (room_id) REFERENCES rooms(id) ON DELETE CASCADE,
+  INDEX idx_rounds_room (room_id),
+  INDEX idx_rounds_status (status)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE IF NOT EXISTS bids (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  round_id INT NOT NULL,
+  player_id INT NOT NULL,
+  value INT NOT NULL,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  FOREIGN KEY (round_id) REFERENCES rounds(id) ON DELETE CASCADE,
+  INDEX idx_bids_round (round_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE IF NOT EXISTS room_players (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  room_id INT NOT NULL,
+  player_id INT NOT NULL,
+  name VARCHAR(255) NULL,
+  points INT NOT NULL DEFAULT 0,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  UNIQUE KEY uniq_room_player (room_id, player_id),
+  FOREIGN KEY (room_id) REFERENCES rooms(id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;


### PR DESCRIPTION
## Summary
- load database credentials from an external PHP config with a sample file and safer defaults
- add Apache rewrite rules for pretty API routes and ignore real secret config files
- ship an idempotent database bootstrap script/schema and replace the README with the new project overview

## Testing
- php -l api/db.php
- php -l db/migrate.php

------
https://chatgpt.com/codex/tasks/task_e_68d0ccbc1d7c832aadd2f04f79d6d053