### PR TITLE
Add room creation endpoint and document secret configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 config.php
 rr-config.php
 .env
+# Per-server Apache overrides (secrets)
+.htaccess.local

--- a/.htaccess
+++ b/.htaccess
@@ -6,3 +6,12 @@ RewriteRule ^api/rooms/([^/]+)/state$ api/state.php?code=$1 [QSA,L]
 
 # /api/rooms/{code}/bid    -> /api/bid.php?code={code}
 RewriteRule ^api/rooms/([^/]+)/bid$   api/bid.php?code=$1   [QSA,L]
+
+# POST /api/rooms/{code}/create -> api/create_room.php?code={code}
+RewriteRule ^api/rooms/([^/]+)/create$ api/create_room.php?code=$1 [QSA,L]
+
+# --- Local overrides (not tracked) ---
+# Allows per-server secrets without committing them to Git.
+# On DreamHost/Apache 2.4 this is supported; if unavailable, admins can paste
+# their SetEnv line directly into .htaccess as a fallback.
+IncludeOptional .htaccess.local

--- a/README.md
+++ b/README.md
@@ -22,15 +22,27 @@ Work in progress. Current MVP includes:
 ## Install (quick start)
 
 1. Create a MySQL database and user on your host.
-2. Copy `config.sample.php` to a **private** location (outside the web root), fill credentials, and set an env var pointing to it:
-   - e.g. in Apache: `SetEnv RR_CONFIG_PATH /home/youruser/secure/rr-config.php`
-3. Run the DB bootstrap:
+2. Copy `config.sample.php` to a **private** location outside the web root (for example `/home/USER/secure/rr-config.php`) and fill in your credentials.
+3. Configure your web server to expose the file via the `RR_CONFIG_PATH` environment variable (see [Secrets](#secrets)).
+4. Run the DB bootstrap:
    - CLI: `php db/migrate.php`
    - or import `db/schema.sql` manually
-4. Deploy the code into your web root.
-5. Hit the API to verify:
+5. Deploy the code into your web root.
+6. Hit the API to verify:
    - `GET /api/rooms/TEST/state?since=-1` → JSON
    - `POST /api/rooms/TEST/bid` with `{"playerId":123,"value":12}` → starts 60s countdown
+
+### Secrets
+
+- Database credentials live in a private PHP array file (e.g., `/home/USER/secure/rr-config.php`) and must **never** be committed to Git.
+- Set the environment variable for Apache by adding the line below to `.htaccess.local` (which is ignored by Git):
+
+  ```apache
+  SetEnv RR_CONFIG_PATH /home/USER/secure/rr-config.php
+  ```
+
+- The repository’s tracked `.htaccess` automatically includes `.htaccess.local` via `IncludeOptional`, so each server can keep its own overrides.
+- `api/db.php` loads configuration in order: the path from `RR_CONFIG_PATH`, then `config.php` (gitignored), and finally `config.sample.php` as a last resort.
 
 ## Pretty API routes
 

--- a/api/bid.php
+++ b/api/bid.php
@@ -40,7 +40,7 @@ try {
     $round = lockRoundForUpdateByRoomCode($code);
     if ($round === null) {
         $pdo->rollBack();
-        respondJson(404, ['error' => 'Room not found or no active round.']);
+        respondJson(404, ['error' => 'Room not found or no active round. Create one via POST /api/rooms/{code}/create.']);
     }
 
     $updated = false;

--- a/api/create_room.php
+++ b/api/create_room.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+require __DIR__ . '/db.php';
+
+header('Cache-Control: no-store, no-cache, must-revalidate');
+
+if (($_SERVER['REQUEST_METHOD'] ?? 'GET') !== 'POST') {
+    header('Allow: POST');
+    respondJson(405, ['error' => 'Method not allowed.']);
+}
+
+$code = isset($_GET['code']) ? trim((string) $_GET['code']) : '';
+if ($code === '') {
+    respondJson(400, ['error' => 'Missing room code.']);
+}
+
+$raw = file_get_contents('php://input');
+$hostPlayerName = null;
+
+if ($raw !== false) {
+    $rawTrimmed = trim($raw);
+    if ($rawTrimmed !== '') {
+        $payload = json_decode($rawTrimmed, true);
+        if (!is_array($payload)) {
+            respondJson(400, ['error' => 'Invalid JSON payload.']);
+        }
+
+        if (array_key_exists('hostPlayerName', $payload) && is_string($payload['hostPlayerName'])) {
+            $hostPlayerName = trim($payload['hostPlayerName']);
+            if ($hostPlayerName === '') {
+                $hostPlayerName = null;
+            }
+        }
+    }
+}
+
+$pdo = db();
+
+try {
+    $pdo->beginTransaction();
+
+    $check = $pdo->prepare('SELECT id FROM rooms WHERE code = :code LIMIT 1');
+    $check->execute(['code' => $code]);
+    $existing = $check->fetch(PDO::FETCH_ASSOC);
+    if ($existing !== false) {
+        $pdo->rollBack();
+        respondJson(409, ['error' => 'Room exists']);
+    }
+
+    $insertRoom = $pdo->prepare('INSERT INTO rooms (code, created_at) VALUES (:code, UTC_TIMESTAMP())');
+    $insertRoom->execute(['code' => $code]);
+    $roomId = (int) $pdo->lastInsertId();
+
+    $roundStmt = $pdo->prepare("INSERT INTO rounds (room_id, status, state_version, created_at) VALUES (:room_id, 'bidding', 0, UTC_TIMESTAMP())");
+    $roundStmt->execute(['room_id' => $roomId]);
+    $roundId = (int) $pdo->lastInsertId();
+
+    if ($hostPlayerName !== null) {
+        $maxPlayerId = (int) min(PHP_INT_MAX, 2147483647);
+        $hostPlayerId = random_int(1, $maxPlayerId);
+
+        $playerStmt = $pdo->prepare('INSERT INTO room_players (room_id, player_id, name, points) VALUES (:room_id, :player_id, :name, 0)');
+        $playerStmt->execute([
+            'room_id'    => $roomId,
+            'player_id'  => $hostPlayerId,
+            'name'       => $hostPlayerName,
+        ]);
+
+        $updateHost = $pdo->prepare('UPDATE rooms SET host_player_id = :player_id WHERE id = :room_id');
+        $updateHost->execute([
+            'player_id' => $hostPlayerId,
+            'room_id'   => $roomId,
+        ]);
+    }
+
+    $pdo->commit();
+} catch (PDOException $e) {
+    if ($pdo->inTransaction()) {
+        $pdo->rollBack();
+    }
+
+    if ($e->getCode() === '23000') {
+        respondJson(409, ['error' => 'Room exists']);
+    }
+
+    respondJson(500, ['error' => 'Unable to create room.']);
+} catch (Throwable $e) {
+    if ($pdo->inTransaction()) {
+        $pdo->rollBack();
+    }
+
+    respondJson(500, ['error' => 'Unable to create room.']);
+}
+
+respondJson(200, [
+    'ok'       => true,
+    'roomCode' => $code,
+    'roomId'   => $roomId,
+    'roundId'  => $roundId,
+]);
+
+function respondJson(int $status, array $payload): void
+{
+    http_response_code($status);
+    header('Content-Type: application/json');
+    echo json_encode($payload);
+    exit;
+}

--- a/api/state.php
+++ b/api/state.php
@@ -22,7 +22,7 @@ while (microtime(true) < $timeoutAt) {
     }
 
     if ($round === null) {
-        respondJson(404, ['error' => 'Room not found or no active round.']);
+        respondJson(404, ['error' => 'Room not found or no active round. Create one via POST /api/rooms/{code}/create.']);
     }
 
     $now = new DateTimeImmutable('now', new DateTimeZone('UTC'));


### PR DESCRIPTION
## Summary
- support per-server overrides by including `.htaccess.local` and wiring the pretty create-room route
- document RR_CONFIG_PATH secrets handling and ignore `.htaccess.local`
- implement `POST /api/rooms/{code}/create` endpoint and hint state/bid errors toward it

## Testing
- php -l api/create_room.php
- php -l api/state.php
- php -l api/bid.php

------
https://chatgpt.com/codex/tasks/task_e_68d21bfac12c832a88c7d1cde4b3bea0