### PR TITLE
Enforce strict bid validation and retire legacy endpoints

### DIFF
--- a/api/lib/bid_logic.php
+++ b/api/lib/bid_logic.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/bid_validation.php';
+
+/**
+ * Apply a validated bid to the current round using the provided callbacks.
+ *
+ * @param array{room_id:mixed,id:mixed,current_low_bid?:mixed} $round
+ * @param callable $ensureRoomPlayer function (int $roomId, int $playerId, ?string $name): void
+ * @param callable $setNewLowBid function (int $roundId, int $playerId, int $value): void
+ * @param callable $insertBid function (int $roundId, int $playerId, int $value): void
+ * @param callable $bumpVersion function (int $roundId): void
+ *
+ * @return array{updatedLow:bool,currentLow:?int}
+ */
+function processBidForRound(
+    array $round,
+    int $playerId,
+    int $bidValue,
+    callable $ensureRoomPlayer,
+    callable $setNewLowBid,
+    callable $insertBid,
+    callable $bumpVersion
+): array {
+    if ($bidValue < 2) {
+        throw new InvalidArgumentException('Bid value must be at least 2.');
+    }
+
+    $roomId = isset($round['room_id']) ? (int) $round['room_id'] : 0;
+    $roundId = isset($round['id']) ? (int) $round['id'] : 0;
+
+    $ensureRoomPlayer($roomId, $playerId, null);
+
+    $currentLow = null;
+    if (array_key_exists('current_low_bid', $round) && $round['current_low_bid'] !== null) {
+        $currentLow = (int) $round['current_low_bid'];
+    }
+
+    $updatedLow = false;
+    if ($currentLow === null || $bidValue < $currentLow) {
+        $setNewLowBid($roundId, $playerId, $bidValue);
+        $currentLow = $bidValue;
+        $updatedLow = true;
+    }
+
+    $insertBid($roundId, $playerId, $bidValue);
+    $bumpVersion($roundId);
+
+    return [
+        'updatedLow' => $updatedLow,
+        'currentLow' => $currentLow,
+    ];
+}

--- a/api/lib/bid_validation.php
+++ b/api/lib/bid_validation.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+final class BidValidationException extends InvalidArgumentException
+{
+}
+
+/**
+ * Normalize and validate an incoming bid payload array.
+ *
+ * @param mixed $payload
+ *
+ * @throws BidValidationException if the payload is invalid
+ */
+function normalizeBidPayload($payload): array
+{
+    if (!is_array($payload)) {
+        throw new BidValidationException('Invalid JSON payload.');
+    }
+
+    if (!array_key_exists('playerId', $payload) || !array_key_exists('value', $payload)) {
+        throw new BidValidationException('playerId and value are required.');
+    }
+
+    $playerId = normalizeIntegerField($payload['playerId'], 'playerId', 1);
+    $bidValue = normalizeIntegerField($payload['value'], 'value', 2);
+
+    return [
+        'playerId' => $playerId,
+        'value'    => $bidValue,
+    ];
+}
+
+/**
+ * Validate that a payload field contains an integer no smaller than $min.
+ *
+ * @param mixed $value
+ * @param non-empty-string $field
+ * @param int $min
+ *
+ * @throws BidValidationException
+ */
+function normalizeIntegerField($value, string $field, int $min): int
+{
+    $trimmed = null;
+    if (is_int($value)) {
+        $normalized = $value;
+    } elseif (is_string($value)) {
+        $trimmed = trim($value);
+        if ($trimmed === '' || preg_match('/^\d+$/', $trimmed) !== 1) {
+            throw new BidValidationException(normalizeIntegerErrorMessage($field, $min));
+        }
+        $normalized = (int) $trimmed;
+    } else {
+        throw new BidValidationException(normalizeIntegerErrorMessage($field, $min));
+    }
+
+    if ($normalized < $min) {
+        throw new BidValidationException(normalizeIntegerErrorMessage($field, $min));
+    }
+
+    return $normalized;
+}
+
+function normalizeIntegerErrorMessage(string $field, int $min): string
+{
+    if ($field === 'value' && $min >= 2) {
+        return 'value must be an integer ≥ 2.';
+    }
+
+    if ($field === 'playerId') {
+        return 'playerId must be a positive integer.';
+    }
+
+    if ($min > 1) {
+        return sprintf('%s must be an integer ≥ %d.', $field, $min);
+    }
+
+    if ($min === 1) {
+        return sprintf('%s must be a positive integer.', $field);
+    }
+
+    return sprintf('%s must be an integer.', $field);
+}

--- a/api/state.php
+++ b/api/state.php
@@ -111,6 +111,9 @@ while (microtime(true) < $timeoutAt) {
         $currentLow = array_key_exists('current_low_bid', $round) && $round['current_low_bid'] !== null
             ? (int) $round['current_low_bid']
             : null;
+        if ($currentLow !== null && $currentLow < 2) {
+            $currentLow = null;
+        }
         $currentLowBy = array_key_exists('current_low_bidder_player_id', $round) && $round['current_low_bidder_player_id'] !== null
             ? (int) $round['current_low_bidder_player_id']
             : null;
@@ -180,8 +183,14 @@ while (microtime(true) < $timeoutAt) {
 
                     $details = $bestBidsByPlayer[$playerId] ?? null;
                     $value = isset($entry['value']) ? (int) $entry['value'] : null;
+                    if ($value !== null && $value < 2) {
+                        $value = null;
+                    }
                     if ($value === null && isset($details['value'])) {
                         $value = (int) $details['value'];
+                        if ($value < 2) {
+                            $value = null;
+                        }
                     }
 
                     $storedQueue[] = [

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -30,7 +30,7 @@ CREATE TABLE IF NOT EXISTS bids (
   id INT AUTO_INCREMENT PRIMARY KEY,
   round_id INT NOT NULL,
   player_id INT NOT NULL,
-  value INT NOT NULL,
+  value SMALLINT UNSIGNED NOT NULL CHECK (value >= 2),
   created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
   FOREIGN KEY (round_id) REFERENCES rounds(id) ON DELETE CASCADE,
   INDEX idx_bids_round (round_id)

--- a/pages/gameManager.php
+++ b/pages/gameManager.php
@@ -434,20 +434,7 @@ class GameManager{
      * @return 0 ok aggiornato correttamente
      */
     function recScore($group, $robot, $move, $numMosse, $time){
-        $fileName = $group.'.csv';
-            
-        if(isset($robot)){
-            $fields = array("$robot","$move");
-        }else{
-            $fields = array("--END--","$time");
-        }
-
-        if( ($roundPath = $this->getRoundPath()) != null){
-            if(file_exists($this->BASE_DIR_ROOT.$roundPath.$fileName) && $numMosse==1) return -2; //group exists
-            return $this->writeOnCSVFile($this->BASE_DIR_ROOT.$roundPath, $fileName, $fields, 'a+');
-        }else{
-            return -1;
-        }
+        throw new RuntimeException('Legacy recScore handler has been removed. Use the API bid endpoint.');
     }
 
     /**

--- a/pages/recScore.php
+++ b/pages/recScore.php
@@ -1,21 +1,8 @@
 <?php
-require_once("gameManager.php");
-$gm = new GameManager();
 
-$group      = null;
-$robot      = null;
-$move       = null;
-$numMosse   = null;
-$time       = null;
+declare(strict_types=1);
 
-if(isset($_REQUEST["g"],$_REQUEST["r"],$_REQUEST["m"],$_REQUEST["s"])){
-    $group    = $gm->test_input($_REQUEST["g"]);    
-    $robot    = $gm->test_input($_REQUEST["r"]);
-    $move     = $gm->test_input($_REQUEST["m"]);
-    $numMosse = $gm->test_input($_REQUEST["s"]);
-}else if(isset($_REQUEST["g"],$_REQUEST["t"]) ){
-    $group    = $gm->test_input($_REQUEST["g"]);    
-    $time     = $gm->test_input($_REQUEST["t"]);
-}
-
-echo $gm->recScore($group, $robot, $move, $numMosse, $time);
+http_response_code(410);
+header('Content-Type: application/json');
+echo json_encode(['error' => 'Legacy bid endpoint removed. Use /api/rooms/{code}/bid instead.']);
+exit;

--- a/public/js/polling.js
+++ b/public/js/polling.js
@@ -149,10 +149,21 @@
   }
 
   async function submitBid(code, playerId, value) {
+    const normalizedPlayerId = typeof playerId === 'string' ? Number.parseInt(playerId, 10) : Number(playerId);
+    if (!Number.isInteger(normalizedPlayerId) || normalizedPlayerId <= 0) {
+      throw new Error('Player ID must be a positive integer');
+    }
+
+    const rawValue = typeof value === 'string' ? value.trim() : value;
+    const normalizedValue = Number(rawValue);
+    if (!Number.isInteger(normalizedValue) || normalizedValue < 2) {
+      throw new Error('Bid must be an integer ≥ 2');
+    }
+
     const res = await fetch(`/api/rooms/${encodeURIComponent(code)}/bid`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ playerId: Number(playerId), value: Number(value) })
+      body: JSON.stringify({ playerId: normalizedPlayerId, value: normalizedValue })
     });
     let data = null;
     try {

--- a/tests/bid_validation_test.php
+++ b/tests/bid_validation_test.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../api/lib/bid_logic.php';
+require_once __DIR__ . '/../api/lib/bid_validation.php';
+
+function ensure(bool $condition, string $message): void
+{
+    if (!$condition) {
+        throw new RuntimeException($message);
+    }
+}
+
+function expectValidationError(callable $callback, string $expected): void
+{
+    try {
+        $callback();
+        ensure(false, 'Expected BidValidationException to be thrown.');
+    } catch (BidValidationException $e) {
+        ensure(strpos($e->getMessage(), $expected) !== false, 'Unexpected validation message: ' . $e->getMessage());
+    }
+}
+
+expectValidationError(function () {
+    normalizeBidPayload(['playerId' => 10, 'value' => 1]);
+}, '≥ 2');
+
+expectValidationError(function () {
+    normalizeBidPayload(['playerId' => 10, 'value' => 9.5]);
+}, 'integer');
+
+$valid = normalizeBidPayload(['playerId' => 7, 'value' => 3]);
+ensure($valid['playerId'] === 7, 'playerId did not normalize to integer.');
+ensure($valid['value'] === 3, 'value did not normalize to integer.');
+
+$validStrings = normalizeBidPayload(['playerId' => '15', 'value' => '12']);
+ensure($validStrings['playerId'] === 15, 'playerId string did not normalize correctly.');
+ensure($validStrings['value'] === 12, 'value string did not normalize correctly.');
+
+$round = [
+    'id' => 1,
+    'room_id' => 1,
+    'current_low_bid' => null,
+];
+
+$records = [];
+$ensureRoomPlayer = static function (int $roomId, int $playerId, ?string $name) use (&$records): void {
+    $records[] = ['type' => 'ensure', 'roomId' => $roomId, 'playerId' => $playerId];
+};
+$setNewLowBid = static function (int $roundId, int $playerId, int $value) use (&$records): void {
+    $records[] = ['type' => 'low', 'roundId' => $roundId, 'playerId' => $playerId, 'value' => $value];
+};
+$insertBid = static function (int $roundId, int $playerId, int $value) use (&$records): void {
+    $records[] = ['type' => 'insert', 'roundId' => $roundId, 'playerId' => $playerId, 'value' => $value];
+};
+$bumpVersion = static function (int $roundId) use (&$records): void {
+    $records[] = ['type' => 'version', 'roundId' => $roundId];
+};
+
+$resultA = processBidForRound($round, 21, 5, $ensureRoomPlayer, $setNewLowBid, $insertBid, $bumpVersion);
+$round['current_low_bid'] = $resultA['currentLow'];
+$resultB = processBidForRound($round, 22, 5, $ensureRoomPlayer, $setNewLowBid, $insertBid, $bumpVersion);
+$round['current_low_bid'] = $resultB['currentLow'];
+
+$inserts = array_values(array_filter($records, static function (array $entry): bool {
+    return $entry['type'] === 'insert';
+}));
+
+ensure(count($inserts) === 2, 'Expected two insert operations for equal bids.');
+ensure($inserts[0]['playerId'] === 21, 'First insert stored wrong player.');
+ensure($inserts[1]['playerId'] === 22, 'Second insert stored wrong player.');
+
+if (PHP_SAPI === 'cli') {
+    fwrite(STDOUT, "All bid validation tests passed.\n");
+}


### PR DESCRIPTION
## Summary
- add reusable bid validation helpers and apply them in /api/rooms/{code}/bid
- harden bid persistence by rejecting values under 2 in queries, schema, and state rendering
- retire legacy recScore handlers, tighten the demo bid form, and add regression tests for validation and duplicate bids

## Testing
- php tests/bid_validation_test.php

------
https://chatgpt.com/codex/tasks/task_e_68d242fb79fc832a91b80d13313a26e7