### PR TITLE
Add lobby landing page and enforce room join gate

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,78 +1,213 @@
-<!--
-******************************************************************************
-* Fabio Lucattini <fabio.ttini [at] gmail.com>
-******************************************************************************
-* RicochetRobot project for MakeFair
-******************************************************************************
-MIT License
-Copyright (c) [2017] [Fabio Lucattini]
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-****************************************************************************** 
--->
-<!DOCTYPE html>  
-<html>
-<head> 
-    <link rel="stylesheet" type="text/css" href="css/base.css">
-<!--    <meta name="viewport" content="width=device-width, initial-scale=1.0"> -->
-    
-        <title>MAKEFAIR - ING. UNIPI TEAM</title> 
-</head> 
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Ricochet Robots — Multiplayer Lobby</title>
+  <style>
+    :root {
+      color-scheme: light dark;
+    }
+    body {
+      margin: 0;
+      font-family: "Inter", "Segoe UI", system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
+      background: linear-gradient(160deg, #0f172a 0%, #1e293b 40%, #020617 100%);
+      color: #0f172a;
+      min-height: 100vh;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: 2.5rem 1.25rem;
+      box-sizing: border-box;
+    }
+    .landing {
+      width: min(640px, 100%);
+      background: rgba(255, 255, 255, 0.95);
+      border-radius: 24px;
+      padding: 2.25rem;
+      box-shadow: 0 35px 60px rgba(15, 23, 42, 0.35);
+      backdrop-filter: blur(18px);
+    }
+    .landing h1 {
+      margin: 0 0 0.5rem;
+      font-size: clamp(1.75rem, 2.8vw + 1rem, 2.4rem);
+      color: #0f172a;
+      font-weight: 700;
+    }
+    .landing p.lead {
+      margin: 0 0 1.75rem;
+      font-size: 1rem;
+      color: #475569;
+    }
+    .tablist {
+      display: inline-flex;
+      border-radius: 999px;
+      padding: 0.25rem;
+      background: rgba(148, 163, 184, 0.25);
+      margin-bottom: 1.5rem;
+    }
+    .tablist button {
+      border: none;
+      background: transparent;
+      color: #475569;
+      font-weight: 600;
+      font-size: 0.95rem;
+      padding: 0.55rem 1.2rem;
+      border-radius: 999px;
+      cursor: pointer;
+      transition: background 140ms ease, color 140ms ease, transform 140ms ease;
+    }
+    .tablist button[aria-selected="true"] {
+      background: #2563eb;
+      color: #fff;
+      box-shadow: 0 10px 30px rgba(37, 99, 235, 0.45);
+    }
+    .panel {
+      display: none;
+    }
+    .panel.is-active {
+      display: block;
+    }
+    form {
+      display: grid;
+      gap: 1rem;
+    }
+    label {
+      font-weight: 600;
+      color: #0f172a;
+      font-size: 0.95rem;
+      display: grid;
+      gap: 0.5rem;
+    }
+    input[type="text"] {
+      padding: 0.65rem 0.85rem;
+      border-radius: 12px;
+      border: 1.5px solid rgba(148, 163, 184, 0.6);
+      font-size: 1.05rem;
+      font-weight: 600;
+      color: #0f172a;
+      transition: border-color 140ms ease, box-shadow 140ms ease;
+    }
+    input[type="text"]:focus {
+      outline: none;
+      border-color: rgba(37, 99, 235, 0.9);
+      box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.2);
+    }
+    input[type="text"][aria-invalid="true"] {
+      border-color: #dc2626;
+      box-shadow: 0 0 0 3px rgba(220, 38, 38, 0.18);
+    }
+    .input-hint {
+      font-size: 0.85rem;
+      color: #64748b;
+      margin: -0.35rem 0 0;
+    }
+    .error-text {
+      font-size: 0.9rem;
+      color: #b91c1c;
+      min-height: 1.2em;
+    }
+    .actions {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.75rem;
+      align-items: center;
+      justify-content: flex-start;
+    }
+    button.primary {
+      padding: 0.7rem 1.5rem;
+      border-radius: 999px;
+      border: none;
+      background: linear-gradient(135deg, #2563eb, #1d4ed8);
+      color: #fff;
+      font-size: 1rem;
+      font-weight: 700;
+      cursor: pointer;
+      transition: transform 140ms ease, box-shadow 140ms ease, filter 140ms ease;
+      box-shadow: 0 18px 30px rgba(37, 99, 235, 0.35);
+    }
+    button.primary:disabled {
+      opacity: 0.65;
+      cursor: not-allowed;
+      box-shadow: none;
+    }
+    button.primary:hover:not(:disabled),
+    button.primary:focus-visible:not(:disabled) {
+      transform: translateY(-1px);
+      box-shadow: 0 24px 45px rgba(37, 99, 235, 0.45);
+      outline: none;
+    }
+    button.secondary {
+      padding: 0.65rem 1.25rem;
+      border-radius: 999px;
+      border: 1px solid rgba(37, 99, 235, 0.6);
+      background: rgba(37, 99, 235, 0.08);
+      color: #1d4ed8;
+      font-weight: 600;
+      cursor: pointer;
+      transition: background 140ms ease, color 140ms ease, transform 140ms ease;
+    }
+    button.secondary:hover,
+    button.secondary:focus-visible {
+      background: rgba(37, 99, 235, 0.18);
+      outline: none;
+      transform: translateY(-1px);
+    }
+    .note {
+      margin-top: 2rem;
+      font-size: 0.9rem;
+      color: #475569;
+      line-height: 1.5;
+    }
+    @media (max-width: 520px) {
+      .landing {
+        padding: 1.75rem;
+        border-radius: 18px;
+      }
+      .tablist button {
+        font-size: 0.9rem;
+        padding-inline: 1rem;
+      }
+    }
+  </style>
+  <script src="/public/js/landing.js" defer></script>
+</head>
 <body>
-    <div id="overlay" class="hideOverlay"></div>
-    <div id="core"></div>
-    <div id="topBar"> 
-        <div class="areaBar">
-            <table class="tabTop">
-                <tr>
-                    <td id="numeroMosse"></td>
-                    <td id="countdown" align="center">TIMER...</td>
-                    <td><button id="btnRandomize" class="btnRandomize" disabled>Randomize layout</button></td>
-                    <td><button id="btnUNDO" class="btnUNDO">UNDO</button></td>
-                    <td><button id="btnRESET" class="btnRESET">RESET</button></td>
-                </tr>
-            </table>
-        </div>
+  <main class="landing">
+    <h1>Ricochet Robots</h1>
+    <p class="lead">Start a fresh room for your group or jump back into an existing one.</p>
+    <div class="tablist" role="tablist" aria-label="Room actions">
+      <button type="button" id="tab-create" role="tab" aria-selected="true" aria-controls="panel-create" data-tab="create">Create room</button>
+      <button type="button" id="tab-join" role="tab" aria-selected="false" aria-controls="panel-join" data-tab="join">Join room</button>
     </div>
-    <script type="text/javascript" src="js/jquery.js"></script>
-    <script type="text/javascript" src="js/overlayManager.js"></script> 
-    <script type="text/javascript" src="js/fileManager.js"></script>
-    <script type="text/javascript" src="js/jsonManager.js"></script>
-    <script type="text/javascript" src="js/tableManager.js"></script>
-    <script type="text/javascript" src="js/robotManager.js"></script>
-    <script type="text/javascript" src="js/layoutRandomizer.js"></script>
-    <script type="text/javascript" src="js/timerManager.js"></script>
-    <script type="text/javascript" src="js/generic.js"></script>
-    <script type="text/javascript" src="js/robotComunication.js"></script>            
-    <script type="text/javascript" src="js/main.js"></script>
-    <script type="text/javascript" src="js/genericConf.js"></script>
-    <script>
-    document.addEventListener('DOMContentLoaded', () => {
-      if (window.randomizeLayout) {
-        window.randomizeLayout(); // run once on load
-      }
-      const btn = document.getElementById('btnRandomize');
-      if (btn) {
-        btn.disabled = false;
-        btn.addEventListener('click', () => window.randomizeLayout && window.randomizeLayout());
-      }
-    });
-    </script>
+    <section id="panel-create" class="panel is-active" role="tabpanel" aria-labelledby="tab-create" data-panel="create">
+      <form id="create-room-form" novalidate>
+        <label for="create-room-code">
+          Room code
+          <input id="create-room-code" name="code" type="text" maxlength="32" pattern="^[a-z][a-z0-9-]{1,31}$" autocomplete="off" autocapitalize="none" spellcheck="false" required>
+        </label>
+        <p class="input-hint">Use lowercase letters, numbers, and hyphen. Start with a letter, 2–32 characters.</p>
+        <div class="actions">
+          <button type="submit" class="primary" id="create-room-submit">Create room</button>
+          <button type="button" class="secondary" id="generate-room-code">New suggestion</button>
+        </div>
+        <p id="create-error" class="error-text" aria-live="polite"></p>
+      </form>
+    </section>
+    <section id="panel-join" class="panel" role="tabpanel" aria-labelledby="tab-join" data-panel="join" hidden>
+      <form id="join-room-form" novalidate>
+        <label for="join-room-code">
+          Room code
+          <input id="join-room-code" name="code" type="text" maxlength="32" pattern="^[a-z][a-z0-9-]{1,31}$" autocomplete="off" autocapitalize="none" spellcheck="false" required>
+        </label>
+        <p class="input-hint">Enter the code shared by the room creator.</p>
+        <div class="actions">
+          <button type="submit" class="primary" id="join-room-submit">Join room</button>
+        </div>
+        <p id="join-error" class="error-text" aria-live="polite"></p>
+      </form>
+    </section>
+    <p class="note">You can reopen the game later using the same code. We’ll remember the last room code you entered on this device.</p>
+  </main>
 </body>
 </html>

--- a/public/demo.html
+++ b/public/demo.html
@@ -20,6 +20,25 @@
     .error { color: #b00020; }
     .message { margin-left: 1rem; font-size: 0.9rem; color: #333; }
     .message.error { color: #b00020; }
+    body.join-gate-open { overflow: hidden; }
+    .join-gate { position: fixed; inset: 0; background: rgba(15, 23, 42, 0.55); backdrop-filter: blur(6px); display: flex; align-items: center; justify-content: center; padding: 1.5rem; z-index: 900; }
+    .join-gate[hidden] { display: none; }
+    .join-gate__panel { width: min(480px, 100%); background: #fff; border-radius: 16px; padding: 1.5rem; box-shadow: 0 24px 60px rgba(15, 23, 42, 0.3); }
+    .join-gate__panel h1 { margin-top: 0; margin-bottom: 0.5rem; font-size: 1.6rem; }
+    .join-gate__room { margin: 0 0 1.25rem; font-size: 0.95rem; color: #475569; font-weight: 600; }
+    .join-gate__room code { display: inline-block; padding: 0.2rem 0.45rem; border-radius: 6px; background: #eef2ff; color: #1d4ed8; }
+    .join-gate form { display: grid; gap: 0.9rem; }
+    .join-gate label { font-weight: 600; margin-bottom: 0.35rem; color: #111827; }
+    .join-gate input, .join-gate select { width: 100%; box-sizing: border-box; }
+    .join-gate button[type="submit"] { margin-top: 0.25rem; }
+    .join-gate__status { margin-top: 0.75rem; }
+    .share-banner { margin-bottom: 1.25rem; padding: 0.75rem 1rem; border-radius: 8px; border: 1px solid #facc15; background: #fef3c7; color: #92400e; display: flex; flex-wrap: wrap; gap: 0.75rem; align-items: center; }
+    .share-banner__text { font-weight: 600; }
+    .share-banner__link { font-weight: 600; color: inherit; word-break: break-word; text-decoration: none; }
+    .share-banner__link:focus-visible, .share-banner__link:hover { text-decoration: underline; }
+    .share-banner__actions { margin-left: auto; display: flex; gap: 0.5rem; align-items: center; }
+    .share-banner__dismiss { border: none; background: transparent; font-size: 1.15rem; line-height: 1; color: inherit; cursor: pointer; padding: 0.25rem; border-radius: 6px; }
+    .share-banner__dismiss:hover, .share-banner__dismiss:focus-visible { background: rgba(250, 204, 21, 0.25); outline: none; }
     .leading-panel { margin-top: 0.75rem; padding: 0.75rem; background: #e9f5ff; border: 1px solid #9cc9f1; border-radius: 4px; }
     .leading-panel strong { font-weight: 600; }
     #bids { list-style: none; padding-left: 0; }
@@ -116,50 +135,61 @@
   </style>
   <script src="/public/js/polling.js" defer></script>
 </head>
-<body>
-  <h1>Ricochet Robot Bidding Demo</h1>
-  <p>Use this page to experiment with the server-authoritative bidding timer. Join the same room code in two tabs to observe live updates.</p>
-
-  <fieldset>
-    <legend>Join Room</legend>
-    <form id="join-form">
-      <label>
-        Room code
-        <input id="room-code" type="text" required minlength="1" maxlength="12" autocomplete="off">
-      </label>
-      <label>
-        Display name
-        <input id="player-name" type="text" maxlength="64" autocomplete="off" required>
-      </label>
-      <label>
-        Player color
-        <div class="color-picker">
-          <span id="color-preview" class="color-preview" aria-hidden="true"></span>
-          <select id="player-color" required>
-            <option value="Purple">Purple</option>
-            <option value="Orange">Orange</option>
-            <option value="Teal">Teal</option>
-            <option value="Magenta">Magenta</option>
-            <option value="Cyan">Cyan</option>
-            <option value="Indigo">Indigo</option>
-            <option value="Amber">Amber</option>
-            <option value="Brown">Brown</option>
-            <option value="Gray">Gray</option>
-            <option value="Pink">Pink</option>
-          </select>
-        </div>
-      </label>
-      <button type="submit">Join / Update</button>
-      <span id="join-message" class="message" aria-live="polite"></span>
-    </form>
-    <div id="join-status" class="banner" hidden aria-live="polite"></div>
+<body class="join-gate-open">
+  <div id="join-gate" class="join-gate" role="dialog" aria-modal="true" aria-labelledby="join-gate-title">
+    <div class="join-gate__panel">
+      <h1 id="join-gate-title">Join the room</h1>
+      <p id="join-gate-room" class="join-gate__room" aria-live="polite" hidden></p>
+      <form id="join-form">
+        <label>
+          Room code
+          <input id="room-code" type="text" required minlength="1" maxlength="32" autocomplete="off" autocapitalize="off" spellcheck="false">
+        </label>
+        <label>
+          Display name
+          <input id="player-name" type="text" maxlength="64" autocomplete="off" required>
+        </label>
+        <label>
+          Player color
+          <div class="color-picker">
+            <span id="color-preview" class="color-preview" aria-hidden="true"></span>
+            <select id="player-color" required>
+              <option value="Purple">Purple</option>
+              <option value="Orange">Orange</option>
+              <option value="Teal">Teal</option>
+              <option value="Magenta">Magenta</option>
+              <option value="Cyan">Cyan</option>
+              <option value="Indigo">Indigo</option>
+              <option value="Amber">Amber</option>
+              <option value="Brown">Brown</option>
+              <option value="Gray">Gray</option>
+              <option value="Pink">Pink</option>
+            </select>
+          </div>
+        </label>
+        <button type="submit">Join room</button>
+        <span id="join-message" class="message" aria-live="polite"></span>
+      </form>
+      <div id="join-status" class="banner join-gate__status" hidden aria-live="polite"></div>
+      <div id="color-warning" class="banner" hidden></div>
+    </div>
+  </div>
+  <div id="room-app" hidden aria-hidden="true">
+    <div id="share-banner" class="share-banner" hidden role="status" aria-live="polite">
+      <span class="share-banner__text">Room created! Share this link with your friends:</span>
+      <a id="share-link" class="share-banner__link" href="" rel="noopener noreferrer"></a>
+      <div class="share-banner__actions">
+        <button type="button" id="share-copy" class="secondary">Copy</button>
+        <button type="button" id="share-dismiss" class="share-banner__dismiss" aria-label="Dismiss banner">✕</button>
+      </div>
+    </div>
+    <h1>Ricochet Robot Bidding Demo</h1>
+    <p>Use this page to experiment with the server-authoritative bidding timer. Join the same room code in two tabs to observe live updates.</p>
     <div class="join-actions">
       <button type="button" id="edit-identity" class="secondary" hidden>Change identity</button>
     </div>
-    <div id="color-warning" class="banner" hidden></div>
-  </fieldset>
 
-  <fieldset id="players-fieldset" hidden>
+    <fieldset id="players-fieldset" hidden>
     <legend>Players</legend>
     <div class="players-header">
       <div><strong id="player-count">0</strong> joined</div>
@@ -263,12 +293,21 @@
     </form>
   </fieldset>
 
+  </div>
+
   <div id="toast" class="toast" aria-live="polite" aria-atomic="true"></div>
 
   <script>
     (function () {
       const joinForm = document.getElementById('join-form');
       const bidForm = document.getElementById('bid-form');
+      const joinGate = document.getElementById('join-gate');
+      const joinGateRoom = document.getElementById('join-gate-room');
+      const roomApp = document.getElementById('room-app');
+      const shareBanner = document.getElementById('share-banner');
+      const shareLink = document.getElementById('share-link');
+      const shareCopyButton = document.getElementById('share-copy');
+      const shareDismissButton = document.getElementById('share-dismiss');
       const roomCodeInput = document.getElementById('room-code');
       const playerNameInput = document.getElementById('player-name');
       const playerColorInput = document.getElementById('player-color');
@@ -277,8 +316,8 @@
       const joinMessage = document.getElementById('join-message');
       const joinStatus = document.getElementById('join-status');
       const bidMessage = document.getElementById('bid-message');
-      const joinButton = joinForm.querySelector('button[type="submit"]');
-      const bidButton = bidForm.querySelector('button[type="submit"]');
+      const joinButton = joinForm ? joinForm.querySelector('button[type="submit"]') : null;
+      const bidButton = bidForm ? bidForm.querySelector('button[type="submit"]') : null;
       const editIdentityButton = document.getElementById('edit-identity');
       const bidInput = document.getElementById('bidInput');
       const playersFieldset = document.getElementById('players-fieldset');
@@ -290,6 +329,10 @@
       const nextRoundButton = document.getElementById('next-round');
       const nextMessage = document.getElementById('next-message');
 
+      const searchParams = new URLSearchParams(window.location.search);
+      let shouldShowShareBanner = searchParams.get('created') === '1';
+      let shareBannerDisplayed = false;
+
       let storedPlayerInfo = null;
       let autoJoinContext = null;
       const pathRoomMatch = window.location.pathname.match(/^\/r\/([^/]+)/i);
@@ -299,10 +342,14 @@
         roomCodeInput.readOnly = true;
         roomCodeInput.setAttribute('aria-readonly', 'true');
         storedPlayerInfo = loadStoredPlayer(initialRoomCode);
+        updateJoinGateRoom(initialRoomCode);
       }
 
       if (!storedPlayerInfo && roomCodeInput.value) {
         storedPlayerInfo = loadStoredPlayer(roomCodeInput.value);
+        if (!initialRoomCode) {
+          updateJoinGateRoom(roomCodeInput.value);
+        }
       }
 
       const globalIdentity = loadGlobalIdentity();
@@ -318,7 +365,7 @@
         const storedColor = canonicalizeColor(storedPlayerInfo.color);
         if (storedColor) {
           playerColorInput.value = storedColor;
-          if (initialRoomCode && storedName) {
+          if (initialRoomCode && storedName && storedPlayerInfo.playerId) {
             autoJoinContext = {
               code: initialRoomCode,
               displayName: storedName,
@@ -472,6 +519,7 @@
       };
       const boardWalls = new Map();
       const robotState = {};
+      let boardInitialized = false;
       let boardActive = false;
       let robotIdx = 0;
       let toastTimeoutId = null;
@@ -554,6 +602,123 @@
         showJoinStatusBanner('');
       }
 
+      function setJoinGateVisible(visible) {
+        if (joinGate) {
+          joinGate.hidden = !visible;
+        }
+        if (visible) {
+          document.body.classList.add('join-gate-open');
+          if (roomApp) {
+            roomApp.setAttribute('aria-hidden', 'true');
+          }
+        } else {
+          document.body.classList.remove('join-gate-open');
+          if (roomApp) {
+            roomApp.removeAttribute('aria-hidden');
+          }
+        }
+      }
+
+      function showRoomApp() {
+        if (roomApp) {
+          roomApp.hidden = false;
+          roomApp.removeAttribute('aria-hidden');
+        }
+      }
+
+      function updateJoinGateRoom(code) {
+        if (!joinGateRoom) {
+          return;
+        }
+        const normalized = normalizeRoomCode(code);
+        if (!normalized) {
+          joinGateRoom.textContent = '';
+          joinGateRoom.hidden = true;
+          return;
+        }
+        const display = normalized.toLowerCase();
+        joinGateRoom.hidden = false;
+        joinGateRoom.textContent = '';
+        const label = document.createElement('span');
+        label.textContent = 'Room code: ';
+        const codeEl = document.createElement('code');
+        codeEl.textContent = display;
+        joinGateRoom.appendChild(label);
+        joinGateRoom.appendChild(codeEl);
+      }
+
+      function getShareUrl(code) {
+        const normalized = normalizeRoomCode(code);
+        if (!normalized) {
+          return window.location.href;
+        }
+        const base = `${window.location.protocol}//${window.location.host}`;
+        return `${base}/r/${encodeURIComponent(normalized.toLowerCase())}`;
+      }
+
+      function consumeCreationFlag() {
+        if (!shouldShowShareBanner) {
+          return;
+        }
+        shouldShowShareBanner = false;
+        try {
+          const url = new URL(window.location.href);
+          url.searchParams.delete('created');
+          const searchString = url.searchParams.toString();
+          const next = `${url.pathname}${searchString ? `?${searchString}` : ''}${url.hash}`;
+          window.history.replaceState(null, '', next);
+        } catch (err) {
+          // Ignore history errors.
+        }
+      }
+
+      function maybeShowShareBanner(code) {
+        if (!shareBanner || shareBannerDisplayed || !shouldShowShareBanner) {
+          return;
+        }
+        const shareUrl = getShareUrl(code);
+        if (shareLink) {
+          shareLink.href = shareUrl;
+          shareLink.textContent = shareUrl;
+        }
+        shareBanner.hidden = false;
+        shareBannerDisplayed = true;
+        consumeCreationFlag();
+      }
+
+      function hideShareBanner() {
+        if (shareBanner) {
+          shareBanner.hidden = true;
+        }
+        shareBannerDisplayed = false;
+        consumeCreationFlag();
+      }
+
+      async function copyShareLink() {
+        const shareUrl = shareLink && shareLink.href ? shareLink.href : window.location.href;
+        if (!shareUrl) {
+          return;
+        }
+        try {
+          if (navigator.clipboard && typeof navigator.clipboard.writeText === 'function') {
+            await navigator.clipboard.writeText(shareUrl);
+          } else {
+            const textArea = document.createElement('textarea');
+            textArea.value = shareUrl;
+            textArea.setAttribute('readonly', '');
+            textArea.style.position = 'absolute';
+            textArea.style.left = '-9999px';
+            document.body.appendChild(textArea);
+            textArea.select();
+            document.execCommand('copy');
+            document.body.removeChild(textArea);
+          }
+          showToast('Link copied to clipboard', false);
+        } catch (err) {
+          showToast('Unable to copy link. Copy it manually.', true);
+        }
+      }
+
       function whenPollingHelpersReady(callback, onTimeout) {
         if (typeof callback !== 'function') {
           return;
@@ -584,7 +749,7 @@
           return '';
         }
         const trimmed = value.trim();
-        return trimmed ? trimmed.toUpperCase() : '';
+        return trimmed ? trimmed.toLowerCase() : '';
       }
 
       function canonicalizeColor(value) {
@@ -654,55 +819,75 @@
         return base;
       }
 
-      function storageKeyForRoom(code) {
-        const normalized = normalizeRoomCode(code);
-        return normalized ? `rr.room.${normalized}` : null;
+      function storagePrefixForRoom(code) {
+        if (typeof code !== 'string') {
+          return null;
+        }
+        const trimmed = code.trim();
+        if (!trimmed) {
+          return null;
+        }
+        return `rr.${trimmed.toLowerCase()}`;
       }
 
       function loadStoredPlayer(code) {
-        const key = storageKeyForRoom(code);
-        if (!key) {
+        const prefix = storagePrefixForRoom(code);
+        if (!prefix) {
           return null;
         }
         try {
-          const raw = window.localStorage.getItem(key);
-          if (!raw) {
-            return null;
-          }
-          const parsed = JSON.parse(raw);
-          if (parsed && typeof parsed === 'object' && typeof parsed.playerId === 'number') {
-            return parsed;
+          const idRaw = window.localStorage.getItem(`${prefix}.playerId`);
+          const nameRaw = window.localStorage.getItem(`${prefix}.displayName`) || '';
+          const colorRaw = window.localStorage.getItem(`${prefix}.color`) || '';
+          const parsedId = idRaw != null ? Number.parseInt(idRaw, 10) : NaN;
+          const playerId = Number.isFinite(parsedId) && parsedId > 0 ? parsedId : null;
+          const displayName = typeof nameRaw === 'string' ? nameRaw : '';
+          const color = typeof colorRaw === 'string' && colorRaw ? colorRaw : null;
+          if (playerId || displayName || color) {
+            return { playerId: playerId, displayName: displayName, color: color };
           }
         } catch (err) {
-          return null;
+          // Ignore storage errors.
         }
         return null;
       }
 
       function saveStoredPlayer(code, playerId, displayName, color) {
-        const key = storageKeyForRoom(code);
-        if (!key) {
+        const prefix = storagePrefixForRoom(code);
+        if (!prefix) {
           return;
         }
         try {
-          const payload = {
-            playerId: Number(playerId) || null,
-            displayName: displayName || '',
-            color: color || null
-          };
-          window.localStorage.setItem(key, JSON.stringify(payload));
+          if (Number.isFinite(Number(playerId)) && Number(playerId) > 0) {
+            window.localStorage.setItem(`${prefix}.playerId`, String(Number(playerId)));
+          } else {
+            window.localStorage.removeItem(`${prefix}.playerId`);
+          }
+          const trimmedName = typeof displayName === 'string' ? displayName.trim() : '';
+          if (trimmedName) {
+            window.localStorage.setItem(`${prefix}.displayName`, trimmedName);
+          } else {
+            window.localStorage.removeItem(`${prefix}.displayName`);
+          }
+          if (color) {
+            window.localStorage.setItem(`${prefix}.color`, color);
+          } else {
+            window.localStorage.removeItem(`${prefix}.color`);
+          }
         } catch (err) {
           // Ignore storage failures.
         }
       }
 
       function clearStoredPlayer(code) {
-        const key = storageKeyForRoom(code);
-        if (!key) {
+        const prefix = storagePrefixForRoom(code);
+        if (!prefix) {
           return;
         }
         try {
-          window.localStorage.removeItem(key);
+          window.localStorage.removeItem(`${prefix}.playerId`);
+          window.localStorage.removeItem(`${prefix}.displayName`);
+          window.localStorage.removeItem(`${prefix}.color`);
         } catch (err) {
           // Ignore.
         }
@@ -1262,6 +1447,7 @@
             saveStoredPlayer(normalizedCode, currentPlayerId, currentPlayerName, currentPlayerColor);
             saveGlobalIdentity(currentPlayerId, currentPlayerName, currentPlayerColor);
             storedPlayerInfo = { playerId: currentPlayerId, displayName: currentPlayerName, color: currentPlayerColor };
+            updateJoinGateRoom(currentRoomCode);
             updateColorPreview(currentPlayerColor);
             setMessage(bidMessage, '', false);
             playersFieldset.hidden = false;
@@ -1301,11 +1487,15 @@
               });
             }
 
-            const identityLabel = formatIdentityLabel(currentPlayerName, currentPlayerColor);
-            showJoinStatusBanner(`Joined as ${identityLabel}.`);
+            ensureBoardReady();
+            showRoomApp();
+            setJoinGateVisible(false);
+            maybeShowShareBanner(currentRoomCode);
+            hideJoinStatusBanner();
             setMessage(joinMessage, '', false);
             setJoinFormVisible(false);
             setEditIdentityVisible(true);
+            const identityLabel = formatIdentityLabel(currentPlayerName, currentPlayerColor);
             if (showToastOnSuccess) {
               showToast(`Joined as ${identityLabel}`, false);
             }
@@ -1373,14 +1563,28 @@
           if (joinInFlight) {
             return;
           }
+          setJoinGateVisible(true);
           setJoinFormVisible(true);
           setEditIdentityVisible(false);
+          updateJoinGateRoom(currentRoomCode || roomCodeInput.value);
           hideJoinStatusBanner();
           setMessage(joinMessage, '', false);
           hideColorWarning();
           if (playerNameInput) {
             playerNameInput.focus({ preventScroll: true });
           }
+        });
+      }
+
+      if (shareCopyButton) {
+        shareCopyButton.addEventListener('click', function () {
+          copyShareLink();
+        });
+      }
+
+      if (shareDismissButton) {
+        shareDismissButton.addEventListener('click', function () {
+          hideShareBanner();
         });
       }
 
@@ -1962,9 +2166,13 @@
       }
 
       function initBoard() {
+        if (boardInitialized) {
+          return;
+        }
         if (!boardEl || !boardGridEl || !robotLayerEl) {
           return;
         }
+        boardInitialized = true;
         if (boardEl.tabIndex < 0) {
           boardEl.tabIndex = 0;
         }
@@ -1995,7 +2203,12 @@
         updateSelectedRobotStyles();
       }
 
-      initBoard();
+      function ensureBoardReady() {
+        if (!boardInitialized) {
+          initBoard();
+        }
+      }
+
       if (toastEl) {
         toastEl.addEventListener('click', hideToast);
       }

--- a/public/js/landing.js
+++ b/public/js/landing.js
@@ -1,0 +1,329 @@
+(function () {
+  const ADJECTIVES = [
+    'brave', 'clever', 'daring', 'eager', 'frosty', 'gentle', 'happy', 'jazzy', 'lively', 'merry',
+    'nimble', 'plucky', 'quick', 'sly', 'sunny', 'swift', 'witty', 'zesty', 'bold', 'calm',
+    'bright', 'cheery', 'cosmic', 'dapper', 'elegant', 'feisty', 'glad', 'kind', 'lucid', 'mighty',
+    'peppy', 'quirky', 'radiant', 'spry', 'tidy', 'vivid', 'whimsical', 'zany'
+  ];
+  const NOUNS = [
+    'badger', 'beaver', 'cougar', 'dragon', 'eagle', 'ferret', 'gibbon', 'heron', 'iguana', 'jaguar',
+    'koala', 'lemur', 'llama', 'marmot', 'narwhal', 'otter', 'panda', 'quokka', 'rabbit', 'seal',
+    'tiger', 'urchin', 'viper', 'walrus', 'yak', 'zorilla', 'falcon', 'goose', 'kiwi', 'owl',
+    'puppy', 'turtle', 'swiftlet', 'lynx', 'panther', 'phoenix', 'sparrow', 'corgi'
+  ];
+  const CODE_REGEX = /^[a-z][a-z0-9-]{1,31}$/;
+  const DOUBLE_HYPHEN = /--/;
+  const LAST_CODE_KEY = 'rr.lastRoomCode';
+
+  function pickRandom(list) {
+    return list[Math.floor(Math.random() * list.length)];
+  }
+
+  function isValidRoomCode(code) {
+    if (typeof code !== 'string') {
+      return false;
+    }
+    return CODE_REGEX.test(code) && !DOUBLE_HYPHEN.test(code);
+  }
+
+  function normalizeGeneratedSlug(text) {
+    if (typeof text !== 'string') {
+      return null;
+    }
+    let slug = text.toLowerCase().replace(/[^a-z0-9-]+/g, '-');
+    slug = slug.replace(/-{2,}/g, '-');
+    slug = slug.replace(/^-+/, '');
+    slug = slug.replace(/-+$/, '');
+    if (!slug) {
+      slug = 'room';
+    }
+    if (!/^[a-z]/.test(slug)) {
+      slug = `r${slug}`;
+    }
+    if (slug.length > 32) {
+      slug = slug.slice(0, 32);
+    }
+    slug = slug.replace(/-+$/, '');
+    if (slug.length < 2) {
+      slug = slug.padEnd(2, 'a');
+    }
+    if (!isValidRoomCode(slug)) {
+      return null;
+    }
+    return slug;
+  }
+
+  function generateRoomCode() {
+    for (let i = 0; i < 20; i += 1) {
+      const suggestion = `${pickRandom(ADJECTIVES)}-${pickRandom(NOUNS)}`;
+      const normalized = normalizeGeneratedSlug(suggestion);
+      if (normalized) {
+        return normalized;
+      }
+    }
+    return 'brave-lion';
+  }
+
+  function sanitizeUserInput(value) {
+    if (typeof value !== 'string') {
+      return '';
+    }
+    return value.trim().toLowerCase();
+  }
+
+  function getLastCode() {
+    try {
+      const stored = window.localStorage.getItem(LAST_CODE_KEY);
+      return typeof stored === 'string' ? stored : '';
+    } catch (err) {
+      return '';
+    }
+  }
+
+  function saveLastCode(code) {
+    try {
+      if (code) {
+        window.localStorage.setItem(LAST_CODE_KEY, code);
+      }
+    } catch (err) {
+      // Ignore storage failures.
+    }
+  }
+
+  function setFieldError(input, errorEl, message) {
+    if (input) {
+      if (message) {
+        input.setAttribute('aria-invalid', 'true');
+      } else {
+        input.removeAttribute('aria-invalid');
+      }
+    }
+    if (errorEl) {
+      errorEl.textContent = message || '';
+    }
+  }
+
+  function validateCode(code) {
+    if (!code) {
+      return 'Enter a room code to continue.';
+    }
+    if (!isValidRoomCode(code)) {
+      return 'Use lowercase letters, numbers, and single hyphen (start with a letter).';
+    }
+    return '';
+  }
+
+  function switchTab(name, elements) {
+    const { tabButtons, panels } = elements;
+    tabButtons.forEach((button) => {
+      const isActive = button.dataset.tab === name;
+      button.setAttribute('aria-selected', isActive ? 'true' : 'false');
+      button.tabIndex = isActive ? 0 : -1;
+    });
+    panels.forEach((panel) => {
+      const isActive = panel.dataset.panel === name;
+      panel.classList.toggle('is-active', isActive);
+      panel.hidden = !isActive;
+    });
+  }
+
+  function focusFirstField(name, refs) {
+    if (name === 'create' && refs.createCodeInput) {
+      refs.createCodeInput.focus({ preventScroll: true });
+    } else if (name === 'join' && refs.joinCodeInput) {
+      refs.joinCodeInput.focus({ preventScroll: true });
+    }
+  }
+
+  function attachTabKeyboardNavigation(container, elements) {
+    if (!container) {
+      return;
+    }
+    container.addEventListener('keydown', (event) => {
+      const key = event.key;
+      if (key !== 'ArrowLeft' && key !== 'ArrowRight') {
+        return;
+      }
+      event.preventDefault();
+      const order = elements.tabButtons;
+      const activeIndex = order.findIndex((btn) => btn.getAttribute('aria-selected') === 'true');
+      if (activeIndex < 0) {
+        return;
+      }
+      const delta = key === 'ArrowLeft' ? -1 : 1;
+      let nextIndex = (activeIndex + delta + order.length) % order.length;
+      const nextButton = order[nextIndex];
+      if (!nextButton) {
+        return;
+      }
+      const targetTab = nextButton.dataset.tab;
+      if (!targetTab) {
+        return;
+      }
+      switchTab(targetTab, elements);
+      focusFirstField(targetTab, elements);
+      nextButton.focus({ preventScroll: true });
+    });
+  }
+
+  function redirectToRoom(code, created) {
+    const encoded = encodeURIComponent(code);
+    const suffix = created ? '?created=1' : '';
+    window.location.href = `/r/${encoded}${suffix}`;
+  }
+
+  document.addEventListener('DOMContentLoaded', () => {
+    const tabButtons = Array.from(document.querySelectorAll('[data-tab]'));
+    const panels = Array.from(document.querySelectorAll('[data-panel]'));
+    const tablist = document.querySelector('.tablist');
+    const createForm = document.getElementById('create-room-form');
+    const createCodeInput = document.getElementById('create-room-code');
+    const createSubmit = document.getElementById('create-room-submit');
+    const createError = document.getElementById('create-error');
+    const regenerateButton = document.getElementById('generate-room-code');
+    const joinForm = document.getElementById('join-room-form');
+    const joinCodeInput = document.getElementById('join-room-code');
+    const joinSubmit = document.getElementById('join-room-submit');
+    const joinError = document.getElementById('join-error');
+
+    const refs = {
+      tabButtons,
+      panels,
+      createCodeInput,
+      joinCodeInput
+    };
+
+    const elements = { tabButtons, panels };
+
+    const suggested = generateRoomCode();
+    if (createCodeInput && !createCodeInput.value) {
+      createCodeInput.value = suggested;
+    }
+
+    const lastCode = getLastCode();
+    if (joinCodeInput && !joinCodeInput.value && lastCode) {
+      joinCodeInput.value = lastCode;
+    }
+
+    tabButtons.forEach((button) => {
+      button.addEventListener('click', () => {
+        const tabName = button.dataset.tab;
+        if (!tabName) {
+          return;
+        }
+        switchTab(tabName, elements);
+        focusFirstField(tabName, refs);
+      });
+    });
+
+    attachTabKeyboardNavigation(tablist, elements);
+
+    if (createCodeInput) {
+      createCodeInput.addEventListener('input', () => {
+        setFieldError(createCodeInput, createError, '');
+      });
+      createCodeInput.addEventListener('blur', () => {
+        if (!createCodeInput) {
+          return;
+        }
+        const formatted = sanitizeUserInput(createCodeInput.value);
+        createCodeInput.value = formatted;
+        const message = validateCode(formatted);
+        if (formatted && message) {
+          setFieldError(createCodeInput, createError, message);
+        }
+      });
+    }
+
+    if (joinCodeInput) {
+      joinCodeInput.addEventListener('input', () => {
+        setFieldError(joinCodeInput, joinError, '');
+      });
+      joinCodeInput.addEventListener('blur', () => {
+        if (!joinCodeInput) {
+          return;
+        }
+        const formatted = sanitizeUserInput(joinCodeInput.value);
+        joinCodeInput.value = formatted;
+        if (formatted) {
+          const message = validateCode(formatted);
+          if (message) {
+            setFieldError(joinCodeInput, joinError, message);
+          }
+        }
+      });
+    }
+
+    if (regenerateButton && createCodeInput) {
+      regenerateButton.addEventListener('click', () => {
+        const next = generateRoomCode();
+        createCodeInput.value = next;
+        setFieldError(createCodeInput, createError, '');
+        createCodeInput.focus({ preventScroll: true });
+      });
+    }
+
+    if (createForm && createSubmit && createCodeInput) {
+      createForm.addEventListener('submit', async (event) => {
+        event.preventDefault();
+        const code = sanitizeUserInput(createCodeInput.value);
+        createCodeInput.value = code;
+        const errorText = validateCode(code);
+        if (errorText) {
+          setFieldError(createCodeInput, createError, errorText);
+          createCodeInput.focus({ preventScroll: true });
+          return;
+        }
+        setFieldError(createCodeInput, createError, '');
+        createSubmit.disabled = true;
+        createSubmit.textContent = 'Creating…';
+        try {
+          const response = await fetch(`/api/rooms/${encodeURIComponent(code)}/create`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({})
+          });
+          if (response.status === 200 || response.status === 409) {
+            saveLastCode(code);
+            redirectToRoom(code, true);
+            return;
+          }
+          let message = 'Unable to create room. Please try again.';
+          try {
+            const data = await response.json();
+            if (data && typeof data.error === 'string' && data.error.trim()) {
+              message = data.error.trim();
+            }
+          } catch (err) {
+            // Ignore parse failures.
+          }
+          setFieldError(createCodeInput, createError, message);
+        } catch (err) {
+          setFieldError(createCodeInput, createError, 'Network error. Check your connection and try again.');
+        } finally {
+          createSubmit.disabled = false;
+          createSubmit.textContent = 'Create room';
+        }
+      });
+    }
+
+    if (joinForm && joinSubmit && joinCodeInput) {
+      joinForm.addEventListener('submit', (event) => {
+        event.preventDefault();
+        const code = sanitizeUserInput(joinCodeInput.value);
+        joinCodeInput.value = code;
+        const errorText = validateCode(code);
+        if (errorText) {
+          setFieldError(joinCodeInput, joinError, errorText);
+          joinCodeInput.focus({ preventScroll: true });
+          return;
+        }
+        setFieldError(joinCodeInput, joinError, '');
+        joinSubmit.disabled = true;
+        joinSubmit.textContent = 'Joining…';
+        saveLastCode(code);
+        redirectToRoom(code, false);
+      });
+    }
+  });
+})();


### PR DESCRIPTION
## Summary
- replace the legacy index page with a create/join lobby that validates friendly room codes and calls the create API
- add a landing.js helper for code generation, validation, and redirects to the room page
- block the room UI behind a join modal that stores per-room identity, delays game init until joined, and shows a share banner for newly created rooms

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d2b33de88c832a9bee3c9dc1eea3db